### PR TITLE
Add geolocation hook and fallback location selector

### DIFF
--- a/src/features/post/components/LocationSelector.tsx
+++ b/src/features/post/components/LocationSelector.tsx
@@ -1,0 +1,80 @@
+import { useEffect, useState } from 'react';
+import useGeolocation from '../../../hooks/useGeolocation';
+import { locationData } from '../../../mockLocations';
+
+export type LocationResult = {
+  latitude?: number;
+  longitude?: number;
+  prefecture?: string;
+  city?: string;
+};
+
+type Props = {
+  onLocationChange: (location: LocationResult) => void;
+};
+
+export default function LocationSelector({ onLocationChange }: Props) {
+  const { coords, error, loading } = useGeolocation();
+  const [prefecture, setPrefecture] = useState('');
+  const [city, setCity] = useState('');
+
+  useEffect(() => {
+    if (coords) {
+      onLocationChange({ latitude: coords.latitude, longitude: coords.longitude });
+    }
+  }, [coords, onLocationChange]);
+
+  useEffect(() => {
+    if (prefecture && city) {
+      onLocationChange({ prefecture, city });
+    }
+  }, [prefecture, city, onLocationChange]);
+
+  const prefectures = Object.keys(locationData);
+  const cities = prefecture ? locationData[prefecture as keyof typeof locationData] : [];
+
+  if (loading) {
+    return <div className="p-2 text-sm">位置情報を取得中...</div>;
+  }
+
+  if (!error && coords) {
+    return (
+      <div className="p-2 text-sm text-green-700">位置情報を取得しました</div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col space-y-2 p-2 bg-gray-100 rounded">
+      <p className="text-sm text-gray-700">位置情報の取得に失敗しました。手動で選択してください。</p>
+      <select
+        value={prefecture}
+        onChange={(e) => {
+          setPrefecture(e.target.value);
+          setCity('');
+        }}
+        className="border rounded p-2 text-sm"
+      >
+        <option value="">都道府県を選択</option>
+        {prefectures.map((p) => (
+          <option key={p} value={p}>
+            {p}
+          </option>
+        ))}
+      </select>
+      {prefecture && (
+        <select
+          value={city}
+          onChange={(e) => setCity(e.target.value)}
+          className="border rounded p-2 text-sm"
+        >
+          <option value="">市区町村を選択</option>
+          {cities.map((c) => (
+            <option key={c} value={c}>
+              {c}
+            </option>
+          ))}
+        </select>
+      )}
+    </div>
+  );
+}

--- a/src/hooks/useGeolocation.ts
+++ b/src/hooks/useGeolocation.ts
@@ -1,0 +1,38 @@
+import { useState, useEffect } from 'react';
+
+export type GeolocationState = {
+  coords?: {
+    latitude: number;
+    longitude: number;
+  };
+  error?: string;
+  loading: boolean;
+};
+
+export default function useGeolocation(): GeolocationState {
+  const [state, setState] = useState<GeolocationState>({ loading: true });
+
+  useEffect(() => {
+    if (!navigator.geolocation) {
+      setState({ loading: false, error: 'Geolocation is not supported' });
+      return;
+    }
+
+    navigator.geolocation.getCurrentPosition(
+      (position) => {
+        setState({
+          loading: false,
+          coords: {
+            latitude: position.coords.latitude,
+            longitude: position.coords.longitude,
+          },
+        });
+      },
+      (err) => {
+        setState({ loading: false, error: err.message });
+      }
+    );
+  }, []);
+
+  return state;
+}

--- a/src/mockLocations.ts
+++ b/src/mockLocations.ts
@@ -1,0 +1,8 @@
+export const locationData = {
+  "東京都": ["新宿区", "渋谷区", "港区"],
+  "大阪府": ["北区", "中央区", "天王寺区"],
+  "福岡県": ["博多区", "中央区", "早良区"],
+} as const;
+
+export type Prefecture = keyof typeof locationData;
+export type City = (typeof locationData)[Prefecture][number];


### PR DESCRIPTION
## Summary
- add geolocation hook to get browser coordinates
- provide location selector component with prefecture/city fallback
- add mock location data for fallback UI

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685ca6b516388327974e7e83c9142fd0