### PR TITLE
Refactor post components

### DIFF
--- a/src/features/post/components/PostForm.tsx
+++ b/src/features/post/components/PostForm.tsx
@@ -1,7 +1,8 @@
 import { useState } from 'react';
+import { PRESETS, Preset } from '../presets';
 
 export type PostInput = {
-  preset: string;
+  preset: Preset;
   message?: string;
 };
 
@@ -9,25 +10,15 @@ type PostFormProps = {
   onSubmit: (post: PostInput) => void;
 };
 
-const presets = [
-  '🛋️ だらけ中',
-  '☕ カフェ中',
-  '🚶‍♀️ 散歩中',
-  '🎮 ゲーム中',
-  '🛏️ 寝ようとしてる',
-  '📖 読書中',
-  '📚 勉強中',
-  '🧘‍♀️ 瞑想中',
-  '✍️ 仕事中',
-];
+const presets = PRESETS;
 
 export default function PostForm({ onSubmit }: PostFormProps) {
-  const [preset, setPreset] = useState(presets[0]);
+  const [preset, setPreset] = useState<Preset>(presets[0]);
   const [message, setMessage] = useState('');
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    onSubmit({ preset, message: message ? message : undefined });
+    onSubmit({ preset, message: message || undefined });
     setMessage('');
   };
 

--- a/src/features/post/postService.ts
+++ b/src/features/post/postService.ts
@@ -17,21 +17,19 @@ export async function createPost(postInput: PostInput): Promise<void> {
     throw new Error('preset is required');
   }
 
+  const location = {
+    ...(typeof latitude === 'number' && { lat: latitude }),
+    ...(typeof longitude === 'number' && { lng: longitude }),
+    ...(prefecture && { prefecture }),
+    ...(city && { city }),
+  };
+
   const data: Record<string, any> = {
     preset,
     message: message ?? null,
     timestamp: serverTimestamp(),
+    ...(Object.keys(location).length && { location }),
   };
-
-  const location: Record<string, any> = {};
-  if (typeof latitude === 'number') location.lat = latitude;
-  if (typeof longitude === 'number') location.lng = longitude;
-  if (prefecture) location.prefecture = prefecture;
-  if (city) location.city = city;
-
-  if (Object.keys(location).length) {
-    data.location = location;
-  }
 
   try {
     await addDoc(collection(db, 'posts'), data);

--- a/src/features/post/presets.ts
+++ b/src/features/post/presets.ts
@@ -1,0 +1,13 @@
+export const PRESETS = [
+  '🛋️ だらけ中',
+  '☕ カフェ中',
+  '🚶‍♀️ 散歩中',
+  '🎮 ゲーム中',
+  '🛏️ 寝ようとしてる',
+  '📖 読書中',
+  '📚 勉強中',
+  '🧘‍♀️ 瞑想中',
+  '✍️ 仕事中',
+] as const;
+
+export type Preset = typeof PRESETS[number];


### PR DESCRIPTION
## Summary
- extract presets list to new file for reusability
- type preset selections with a new `Preset` type
- simplify message handling and `createPost` location building

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688303d16828832786afbf7782e81c92